### PR TITLE
use cache for hexists

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,20 +1,6 @@
 name: CI
 
-on:
-  push:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.rst'
-      - '**/*.md'
-    branches:
-      - master
-      - '[0-9].[0-9]'
-  pull_request:
-    branches:
-      - master
-      - '[0-9].[0-9]'
-  schedule:
-    - cron: '0 1 * * *' # nightly build
+on: [push, pull]
 
 jobs:
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -3,7 +3,6 @@ name: CI
 on: [push, pull]
 
 jobs:
-
    dependency-audit:
      name: Dependency audit
      runs-on: ubuntu-latest

--- a/.github/workflows/popper.yml
+++ b/.github/workflows/popper.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -44,3 +44,5 @@ jobs:
 
     - name: Test
       run: |
+        pytest tests/redis_popper
+        

--- a/.github/workflows/popper.yml
+++ b/.github/workflows/popper.yml
@@ -1,0 +1,46 @@
+name: redis-popper
+
+on: [push, pull_request]
+
+
+jobs:
+  python_ci:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        python -m pip install -r requirements.txt
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Setup Redis
+      # You may pin to the exact commit or the version.
+      # uses: getong/redis-action@1451151d211b1af327efbf4587f82ec5509cc2f6
+      uses: getong/redis-action@v1
+      with:
+        redis version: 7.0-rc3
+
+    - name: Verify that redis is up
+      run: |
+       sudo apt-get install -y redis-tools redis-server
+       redis-cli ping
+    - name: Lint with flake8
+      run: |
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics
+
+    - name: Test
+      run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 redis.egg-info
+redis_popper.egg-info
 build/
 dist/
 dump.rdb

--- a/redis/commands/core.py
+++ b/redis/commands/core.py
@@ -72,7 +72,7 @@ def to_bytes(val: Union[str, bytes, memoryview]):
         return bytes(val)
 
 
-def get_from_cache(rds, key: str, get_cmd: str = 'GET') -> Tuple[Any, bool]:
+def get_from_cache(rds, key: str, get_cmd: Union[str, None] = 'GET') -> Tuple[Any, bool]:
     """
     Gets key from cache if exists,
     Otherwise gets key from redis(if get_cmd is not None), saves in the cache and returns
@@ -4820,10 +4820,10 @@ class HashCommands(CommandsProtocol):
 
         For more information see https://redis.io/commands/hexists
         """
-        # HEXISTS is may be used to check a key before creating it.
-        # So, to not save it in cache yet, use get_cmd=None.
+        # HEXISTS may be used to check a key before creating it.
+        # So, don't save it in cache yet, use get_cmd=None.
         # This will return the val if it was already there in cache.
-        # If it was not there, the cache won't be updated.
+        # If it was not there, the cache won't be updated and we will get None.
         val, used_cache = get_from_cache(self, name, get_cmd=None)
         if val is not None:
             return to_bytes(key) in val

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     long_description_content_type="text/markdown",
     keywords=["Redis", "key-value store", "database"],
     license="MIT",
-    version="4.4.3",
+    version="4.4.4",
     packages=find_packages(
         include=[
             "redis",

--- a/test.py
+++ b/test.py
@@ -1,0 +1,149 @@
+import math
+import time
+
+from redis.client import Redis
+from redis.key_types import KeyCacheProp
+
+
+def bench():
+    keys = {"c": KeyCacheProp.WRITE_ONCE}
+    r = Redis(host='localhost', key_types=keys)
+
+    r.flushall()
+
+    r.set('x', 'a')
+    r.set('x:c', 'a')
+    r.get('x:c')
+
+    st = time.time()
+    print(r.get('x:c'))
+    ed = time.time()
+    print((ed - st))
+
+    st = time.time()
+    print(r.get('x'))
+    ed = time.time()
+    print((ed - st))
+
+    print("------------")
+
+    for i in range(10):
+        r.hset('y:c', str(i), str(i))
+        r.hset('y', str(i), str(i))
+
+    for i in range(10):
+        r.hget('y:c', str(i))
+
+    st = time.time()
+    r.hget('y:c', '5')
+    ed = time.time()
+    print((ed - st))
+
+    t1 = ed - st
+
+    st = time.time()
+    r.hget('y', '5')
+    ed = time.time()
+    print((ed - st))
+
+    t2 = ed - st
+
+    print("hget saved:", abs(t2 - t1) * 1000, "ms")
+
+    print("------------")
+
+    st = time.time()
+    r.hgetall('y:c')
+    ed = time.time()
+    print((ed - st))
+
+    t1 = ed - st
+
+    st = time.time()
+    r.hgetall('y')
+    ed = time.time()
+    print((ed - st))
+
+    t2 = ed - st
+
+    print("hgetall saved", abs(t2 - t1) * 1000, "ms")
+
+    print("------------")
+
+    st = time.time()
+    r.hmget('y:c', '1', '2', '3', '4')
+    ed = time.time()
+    print((ed - st) )
+
+    st = time.time()
+    r.hmget('y', '1', '2', '3', '4')
+    ed = time.time()
+    print((ed - st) )
+
+    print("hmget saved", abs(t2 - t1) * 1000, "ms")
+
+
+def test_flush():
+    keys = {"c": KeyCacheProp.WRITE_ONCE}
+    r = Redis(host='localhost', key_types=keys)
+    r.set("kk:c", "kkk")
+    assert r.get("kk:c") is not None
+    print(r.get("kk:c"))
+    r.flushall()
+    assert r.get("kk:c") is None
+
+
+# def test_async_writer():
+#     r = Redis()
+#     r.flushall()
+#
+#     ar = AsyncWriter()
+#
+#     for i in range(100):
+#         ar.set(str(i), i)
+#
+#     ar.wait_all()
+#
+#     for i in range(100):
+#         x = r.get(str(i))
+#         assert int(x) == i
+
+
+
+# def bench_async_writer():
+#     r = Redis()
+#     r.flushall()
+#
+#     ar = AsyncWriter()
+#
+#     def bench(rds):
+#         for i in range(10000):
+#             x = math.factorial(i % 5000) + 3 // 7
+#             rds.set(str(i), x % 100)
+#
+#     st = time.time()
+#     bench(ar)
+#     ar.wait_all()
+#     ed = time.time()
+#
+#     print("async writes:", ed - st)
+#
+#     r.flushall()
+#
+#     st = time.time()
+#     bench(r)
+#     ed = time.time()
+#     print("sync writes:", ed - st)
+
+    #
+    #
+    # for i in range(1000):
+    #     print(r.get(str(i)))
+
+#
+# if __name__ == "__main__":
+#     # bench()
+#     # test_flush()
+#     # print("test")
+#     test_async_writer()
+#     bench_async_writer()

--- a/tests/redis_popper/test_write_once.py
+++ b/tests/redis_popper/test_write_once.py
@@ -1,0 +1,63 @@
+import math
+import time
+
+from redis.client import Redis
+from redis.key_types import KeyCacheProp
+
+
+def timed(f, *args, **kwargs):
+    st = time.time()
+    ret = f(*args, **kwargs)
+    ed = time.time()
+    return ret, ed - st
+
+def test_write_once():
+    print('')
+    SUFFIX = "C"
+    def suffixed(key):
+        return key + ":" + SUFFIX
+
+    key_types = {SUFFIX : KeyCacheProp.WRITE_ONCE}
+    r = Redis(host='localhost', key_types=key_types)
+    r.flushall()
+    def write_once_cmd_test(set_cmd, get_cmd, set_args, get_args):
+        key = set_args[0]
+        set_cmd(*set_args)
+        ve, t1 = timed(get_cmd, *get_args)
+        key = suffixed(key)
+        set_args[0] = key
+        get_args[0] = key
+        set_cmd(*set_args)
+        v, t2 = timed(get_cmd, *get_args)
+        assert v == ve
+        v, t3 = timed(get_cmd, *get_args)
+        assert v == ve
+
+        assert t1 - t3 >= 0.05 * 1e-3
+        assert t2 - t3 >= 0.05 * 1e-3
+
+        print(get_cmd.__name__, t1, t2, t3)
+        print(v)
+
+    write_once_cmd_test(r.set, r.get, ['get', 'val'], ['get'])
+
+    write_once_cmd_test(r.hset, r.hget, ['hget', 'key', 'val'], ['hget','key'])
+
+    write_once_cmd_test(r.hset, r.hgetall, ['hgetall', None, None, {'k1':'v1', 'k2':'v2'}], ['hgetall'])
+
+    write_once_cmd_test(r.hset, r.hmget, ['hmget', None, None, {'k1':'v1', 'k2':'v2', 'k3':'v3'}],
+                        ['hmget', ['k2', 'k3']])
+
+    assert not r.hexists(suffixed('no'), 'key')
+    assert not r.hexists(suffixed('no'), 'key')
+
+    write_once_cmd_test(r.hset, r.hexists, ['hexists', None, None, {'k1':'v1', 'k2':'v2', 'k3':'v3'}],
+                        ['hexists', 'k2'])
+
+def test_flush():
+    keys = {"c": KeyCacheProp.WRITE_ONCE}
+    r = Redis(host='localhost', key_types=keys)
+    r.set("k:c", "k")
+    assert r.get("k:c") is not None
+    r.flushall()
+    assert r.get("k:c") is None


### PR DESCRIPTION
Use cache of `HEXISTS`.   

On each read row, we were doing `HEXISTS` in schema.   

After caching, on a word count with ~2k words file, we are saving ~5k Redis `HEXISTS`.  

Latency for a Redis command on localhost : 0.1ms. 

5000 * 0.1 = 500ms saved.